### PR TITLE
[FEAT] 좋아요 중복 방지 함수(공통 좋아요 추가 수정) 및 RESTAURANT_POST 함수 수정

### DIFF
--- a/src/api/supabase-api/commonLikeWithoutDuplication.js
+++ b/src/api/supabase-api/commonLikeWithoutDuplication.js
@@ -1,0 +1,45 @@
+import { supabase } from "@/supabase";
+
+/**
+ * 좋아요를 추가하고 중복 여부를 확인하는 함수
+ * @param {string} tableName - 좋아요를 추가할 테이블 이름
+ * @param {number} postId - 좋아요를 누를 포스트 ID
+ * @param {number} memberId - 좋아요를 누르는 사용자 ID
+ * @returns {Promise<string>} - 'Like added' 또는 'Already liked'
+ */
+const addcommonLike = async (tableName, postId, memberId) => {
+  const { data, error } = await supabase.rpc("add_like_to_table", {
+    table_name: tableName,
+    input_post_id: postId,
+    input_member_id: memberId,
+  });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data; // 'Like added' 또는 'Already liked' 반환
+};
+
+/**
+ * 좋아요를 삭제하는 함수
+ * @param {string} tableName - 좋아요를 삭제할 테이블 이름
+ * @param {number} postId - 좋아요를 취소할 포스트 ID
+ * @param {number} memberId - 좋아요를 취소하는 사용자 ID
+ * @returns {Promise<string>} - 'Like removed' 또는 'Like not found'
+ */
+const removecommonLike = async (tableName, postId, memberId) => {
+  const { data, error } = await supabase.rpc("remove_like_from_table", {
+    table_name: tableName,
+    input_post_id: postId,
+    input_member_id: memberId,
+  });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  return data; // 'Like removed' 또는 'Like not found' 반환
+};
+
+export default { addcommonLike, removecommonLike };

--- a/src/api/supabase-api/freePost.js
+++ b/src/api/supabase-api/freePost.js
@@ -1,7 +1,6 @@
 import { supabase } from "./../../../src/supabase.js";
 
-// Create
-// 자유 게시물 작성 (free_post)
+// 자유 게시물 작성 
 async function createFreePost(memberId, content, title, thumbnailUrl, clubId) {
   const { data, error } = await supabase
     .from("free_post")
@@ -14,17 +13,17 @@ async function createFreePost(memberId, content, title, thumbnailUrl, clubId) {
         club_id: clubId,
       },
     ])
-    .select(); // 삽입된 데이터 반환
+    .select(); 
 
   if (error) {
     console.error("Error creating free post:", error);
     return null;
   }
 
-  return data; // 생성된 자유 게시물 반환
+  return data; 
 }
 
-// 자유 게시물에 좋아요 추가 (free_post_like)
+// 자유 게시물에 좋아요 추가 
 async function createFreePostLike(memberId, postId) {
   const { data, error } = await supabase
     .from("free_post_like")
@@ -37,7 +36,7 @@ async function createFreePostLike(memberId, postId) {
   return data;
 }
 
-// 자유 게시물에 댓글 추가 (free_post_comment)
+// 자유 게시물에 댓글 추가 
 async function createFreePostComment(memberId, postId, content) {
   const { data, error } = await supabase
     .from("free_post_comment")
@@ -47,17 +46,15 @@ async function createFreePostComment(memberId, postId, content) {
     console.error("Error creating free post comment:", error);
     return null;
   }
-  return data; // 생성된 댓글 데이터를 반환
+  return data; 
 }
 
-// Read
-
-// 특정 구단의 전체 게시물 조회 (free_post)
+// 특정 구단의 전체 게시물 조회 
 async function getAllFreePostsByClub(clubId) {
   const { data, error } = await supabase
     .from("free_post")
     .select("*")
-    .eq("club_id", clubId); // club_id로 필터링
+    .eq("club_id", clubId); 
 
   if (error) {
     console.error("Error fetching free posts for the club:", error);
@@ -66,13 +63,13 @@ async function getAllFreePostsByClub(clubId) {
   return data;
 }
 
-// 특정 자유 게시물 조회 (free_post)
+// 특정 자유 게시물 조회 
 async function getFreePostById(postId) {
   const { data, error } = await supabase
     .from("free_post")
     .select("*")
-    .eq("id", postId) // 'id'가 postId와 일치하는 게시물을 조회
-    .single(); // 하나의 게시물만 반환
+    .eq("id", postId) 
+    .single(); 
 
   if (error) {
     console.error("Error fetching free post:", error);
@@ -81,7 +78,7 @@ async function getFreePostById(postId) {
   return data;
 }
 
-// 자유 게시물 좋아요 조회 (free_post_like)
+// 자유 게시물 좋아요 조회 
 async function getFreePostLikes(postId) {
   const { data, error } = await supabase
     .from("free_post_like")
@@ -95,7 +92,7 @@ async function getFreePostLikes(postId) {
   return data;
 }
 
-// 자유 게시물 댓글 조회 (free_post_comment)
+// 자유 게시물 댓글 조회
 async function getFreePostComments(postId) {
   const { data, error } = await supabase
     .from("free_post_comment")
@@ -109,9 +106,8 @@ async function getFreePostComments(postId) {
   return data;
 }
 
-// Update
 
-// 자유 게시물 수정 (free_post)
+// 자유 게시물 수정
 async function updateFreePost(postId, content, title, thumbnailUrl) {
   const { data, error } = await supabase
     .from("free_post")
@@ -125,7 +121,7 @@ async function updateFreePost(postId, content, title, thumbnailUrl) {
   return data;
 }
 
-// 자유 게시물 좋아요 취소 (free_post_like)
+// 자유 게시물 좋아요 취소 
 async function updateFreePostLike(postId, memberId) {
   const { data, error } = await supabase
     .from("free_post_like")
@@ -140,7 +136,7 @@ async function updateFreePostLike(postId, memberId) {
   return data;
 }
 
-// 자유 게시물 댓글 수정 (free_post_comment)
+// 자유 게시물 댓글 수정
 async function updateFreePostComment(commentId, content) {
   const { data, error } = await supabase
     .from("free_post_comment")
@@ -154,9 +150,7 @@ async function updateFreePostComment(commentId, content) {
   return data;
 }
 
-// Delete
-
-// 자유 게시물 삭제 (free_post)
+// 자유 게시물 삭제
 async function deleteFreePost(postId) {
   const { data, error } = await supabase
     .from("free_post")
@@ -170,7 +164,7 @@ async function deleteFreePost(postId) {
   return data;
 }
 
-// 자유 게시물 댓글 삭제 (free_post_comment)
+// 자유 게시물 댓글 삭제
 async function deleteFreePostComment(commentId) {
   const { data, error } = await supabase
     .from("free_post_comment")

--- a/src/api/supabase-api/getPostsByMyId.js
+++ b/src/api/supabase-api/getPostsByMyId.js
@@ -1,7 +1,8 @@
-import { supabase } from "./../../../src/supabase.js";
+// import { supabase } from "./../../supabase.js";
+import { supabase } from "@/supabase";
 
 /**
- * 특정 멤버 ID로 게시물을 가져오는 함수
+ * 특정 멤버 ID로 게시물을 가져오는 함수 ✅
  * @param {string} memberId
  * @returns {Promise<Array>}
  */
@@ -38,25 +39,8 @@ async function getPostsByMemberId(memberId) {
   }
 }
 
-(async () => {
-  const memberId = "d9ac20dc-af86-42e8-9d63-5f1e35b20547";
-  const posts = await getPostsByMemberId(memberId);
-  console.log("원본 데이터", posts);
-  if (posts && posts.length > 0) {
-    posts.forEach((post) => {
-      console.log(`Post ID: ${post.post_id}`);
-      console.log(`Post Type: ${post.post_type}`);
-      console.log(`Title: ${post.post_title || "No Title"}`);
-      console.log(`Thumbnail: ${post.thumbnail_url || "No Thumbnail"}`);
-      console.log("---");
-    });
-  } else {
-    console.log("No posts found or error occurred.");
-  }
-})();
-
 /**
- * 특정 멤버 ID로 좋아요한 게시물을 가져오는 함수
+ * 특정 멤버 ID로 좋아요한 게시물을 가져오는 함수 ✅
  * @param {string} memberId - 멤버 ID
  * @returns {Promise<Array>} - 좋아요한 게시물 배열
  */
@@ -93,27 +77,8 @@ async function getLikedPostsByMemberId(memberId) {
   }
 }
 
-(async () => {
-  const memberId = "d9ac20dc-af86-42e8-9d63-5f1e35b20547"; // 테스트용 멤버 ID
-  const likedPosts = await getLikedPostsByMemberId(memberId);
-
-  console.log("좋아요한 게시물 데이터:", likedPosts);
-
-  if (likedPosts && likedPosts.length > 0) {
-    likedPosts.forEach((post) => {
-      console.log(`Post ID: ${post.post_id}`);
-      console.log(`Post Type: ${post.post_type}`);
-      console.log(`Title: ${post.post_title || "No Title"}`);
-      console.log(`Thumbnail: ${post.thumbnail_url || "No Thumbnail"}`);
-      console.log("---");
-    });
-  } else {
-    console.log("No liked posts found or an error occurred.");
-  }
-})();
-
 /**
- * 특정 멤버 ID로 댓글 단 게시물을 가져오는 함수
+ * 특정 멤버 ID로 댓글 단 게시물을 가져오는 함수 ✅
  * @param {string} memberId - 멤버 ID
  * @returns {Promise<Array>} - 댓글 단 게시물 배열
  */
@@ -153,21 +118,8 @@ async function getCommentedPostsByMemberId(memberId) {
   }
 }
 
-(async () => {
-  const memberId = "d9ac20dc-af86-42e8-9d63-5f1e35b20547"; // 테스트용 멤버 ID
-  const commentedPosts = await getCommentedPostsByMemberId(memberId);
-
-  console.log("댓글 단 게시물 데이터:", commentedPosts);
-
-  if (commentedPosts && commentedPosts.length > 0) {
-    commentedPosts.forEach((post) => {
-      console.log(`Post ID: ${post.post_id}`);
-      console.log(`Post Type: ${post.post_type}`);
-      console.log(`Title: ${post.post_title || "No Title"}`);
-      console.log(`Thumbnail: ${post.thumbnail_url || "No Thumbnail"}`);
-      console.log("---");
-    });
-  } else {
-    console.log("No commented posts found or an error occurred.");
-  }
-})();
+export {
+  getPostsByMemberId,
+  getLikedPostsByMemberId,
+  getCommentedPostsByMemberId,
+};

--- a/src/api/supabase-api/restaurantComment.js
+++ b/src/api/supabase-api/restaurantComment.js
@@ -1,4 +1,4 @@
-import { supabase } from "./../../../src/supabase.js";
+import { supabase } from "@/supabase";
 
 // 댓글 추가
 const createRestaurantPostComment = async (memberId, postId, content) => {

--- a/src/api/supabase-api/restaurantImage.js
+++ b/src/api/supabase-api/restaurantImage.js
@@ -1,142 +1,66 @@
-import { supabase } from "./../../../src/supabase.js";
+import { supabase } from "@/supabase";
 
-const restaurantPostImageService = {
-  // 이미지 추가
-  createRestaurantPostImage: async (postId, imageUrl, imageIndex) => {
-    const { data, error } = await supabase
-      .from("restaurant_post_image")
-      .insert([{ post_id: postId, url: imageUrl, order_index: imageIndex }]);
+// 이미지 추가 ✅
+const createRestaurantPostImage = async (postId, imageUrl, imageIndex) => {
+  const { data, error } = await supabase
+    .from("restaurant_post_image")
+    .insert([{ post_id: postId, url: imageUrl, order_index: imageIndex }]);
 
-    if (error) {
-      console.error("Error creating restaurant post image:", error);
-      return null;
-    }
+  if (error) {
+    console.error("Error creating restaurant post image:", error);
+    return null;
+  }
 
-    return data;
-  },
-
-  // 특정 게시물의 이미지 조회
-  getRestaurantPostImages: async (postId) => {
-    const { data, error } = await supabase
-      .from("restaurant_post_image")
-      .select("*")
-      .eq("post_id", postId);
-
-    if (error) {
-      console.error("Error fetching restaurant post images:", error);
-      return null;
-    }
-    return data;
-  },
-
-  // 특정 게시물의 특정 번호 이미지 수정
-  updateRestaurantPostImage: async (postId, orderIndex, imageUrl) => {
-    const { data, error } = await supabase
-      .from("restaurant_post_image")
-      .update({ url: imageUrl })
-      .eq("post_id", postId)
-      .eq("order_index", orderIndex);
-
-    if (error) {
-      console.error("Error updating restaurant post image:", error);
-      return null;
-    }
-    return data;
-  },
-
-  // 게시물 이미지 삭제
-  deleteRestaurantPostImage: async (postId, orderIndex) => {
-    const { data, error } = await supabase
-      .from("restaurant_post_image")
-      .delete()
-      .eq("post_id", postId)
-      .eq("order_index", orderIndex); // order_index로 필터링
-
-    if (error) {
-      console.error("Error deleting restaurant post image:", error);
-      return null;
-    }
-    return data;
-  },
-
-  // 게시물 이미지 추가 테스트
-  testCreateRestaurantPostImage: async () => {
-    const postId = 33; // 테스트할 게시물 ID
-    const imageUrl = "http://example.com/image.jpg";
-    const orderIndex = 2;
-    try {
-      const image = await restaurantPostImageService.createRestaurantPostImage(
-        postId,
-        imageUrl,
-        orderIndex
-      );
-      console.log("게시물 이미지 추가 성공:", image);
-    } catch (error) {
-      console.error("Error testing createRestaurantPostImage:", error);
-    }
-  },
-
-  // 맛집 게시물 이미지 조회 테스트
-  testGetRestaurantPostImages: async () => {
-    const postId = 33; // 테스트할 게시물 ID
-
-    try {
-      const images = await restaurantPostImageService.getRestaurantPostImages(
-        postId
-      );
-      console.log("게시물 이미지 조회 성공:", images);
-    } catch (error) {
-      console.error("Error testing getRestaurantPostImages:", error);
-    }
-  },
-
-  // 맛집 게시물 이미지 수정 테스트
-  testUpdateRestaurantPostImage: async () => {
-    const postId = 1; // 수정할 게시물 ID
-    const orderIndex = 1;
-    const newImageUrl = "http://newimage11.jpg";
-
-    try {
-      const updatedImage =
-        await restaurantPostImageService.updateRestaurantPostImage(
-          postId,
-          orderIndex,
-          newImageUrl
-        );
-      console.log("게시물 이미지 수정 성공:", updatedImage);
-    } catch (error) {
-      console.error("Error testing updateRestaurantPostImage:", error);
-    }
-  },
-
-  // 맛집 게시물 이미지 삭제 테스트
-  testDeleteRestaurantPostImage: async () => {
-    const postId = 33; // 삭제할 게시물 ID
-    const orderIndex = 2;
-
-    try {
-      const deletedImage =
-        await restaurantPostImageService.deleteRestaurantPostImage(
-          postId,
-          orderIndex
-        );
-      console.log("게시물 이미지 삭제 성공:", deletedImage);
-    } catch (error) {
-      console.error("Error testing deleteRestaurantPostImage:", error);
-    }
-  },
-
-  // 테스트 실행 함수
-  runAllTests: async () => {
-    console.log("테스트 시작...");
-
-    await restaurantPostImageService.testCreateRestaurantPostImage(); // 게시물 이미지 추가 테스트
-    await restaurantPostImageService.testGetRestaurantPostImages(); // 게시물 이미지 조회 테스트
-    await restaurantPostImageService.testUpdateRestaurantPostImage(); // 게시물 이미지 수정 테스트
-    await restaurantPostImageService.testDeleteRestaurantPostImage(); // 게시물 이미지 삭제 테스트
-
-    console.log("모든 테스트가 완료되었습니다.");
-  },
+  return data;
 };
 
-export default restaurantPostImageService;
+// 특정 게시물의 이미지 조회 ✅
+const getRestaurantPostImages = async (postId) => {
+  const { data, error } = await supabase
+    .from("restaurant_post_image")
+    .select("*")
+    .eq("post_id", postId);
+
+  if (error) {
+    console.error("Error fetching restaurant post images:", error);
+    return null;
+  }
+  return data;
+};
+
+// 특정 게시물의 특정 번호 이미지 수정 ✅
+const updateRestaurantPostImage = async (postId, orderIndex, imageUrl) => {
+  const { data, error } = await supabase
+    .from("restaurant_post_image")
+    .update({ url: imageUrl })
+    .eq("post_id", postId)
+    .eq("order_index", orderIndex);
+
+  if (error) {
+    console.error("Error updating restaurant post image:", error);
+    return null;
+  }
+  return data;
+};
+
+// 게시물 이미지 삭제 ✅
+const deleteRestaurantPostImage = async (postId, orderIndex) => {
+  const { data, error } = await supabase
+    .from("restaurant_post_image")
+    .delete()
+    .eq("post_id", postId)
+    .eq("order_index", orderIndex); // order_index로 필터링
+
+  if (error) {
+    console.error("Error deleting restaurant post image:", error);
+    return null;
+  }
+  return data;
+};
+
+export default {
+  createRestaurantPostImage,
+  getRestaurantPostImages,
+  updateRestaurantPostImage,
+  deleteRestaurantPostImage,
+};

--- a/src/api/supabase-api/restaurantLike.js
+++ b/src/api/supabase-api/restaurantLike.js
@@ -1,4 +1,4 @@
-import { supabase } from "./../../../src/supabase.js";
+import { supabase } from "@/supabase";
 
 const createRestaurantPostLike = async (memberId, postId) => {
   const { data, error } = await supabase

--- a/src/api/supabase-api/restaurantPost.js
+++ b/src/api/supabase-api/restaurantPost.js
@@ -1,0 +1,138 @@
+import { supabase } from "@/supabase";
+
+// 게시물 작성 ✅
+const createRestaurantPost = async (
+  memberId,
+  content,
+  title,
+  thumbnailUrl,
+  tags,
+  clubId
+) => {
+  const { data: postData, error: postError } = await supabase
+    .from("restaurant_post")
+    .insert([
+      {
+        member_id: memberId,
+        content,
+        title,
+        thumbnail_url: thumbnailUrl,
+        tags,
+        club_id: clubId,
+      },
+    ])
+    .select();
+
+  if (postError) {
+    console.error("Error creating restaurant post:", postError);
+    return null;
+  }
+
+  return postData;
+};
+
+// 특정 태그의 맛집 게시물 조회 (SQL로 처리) ✅
+export const getRestaurantPostsByTagAndClub = async (clubId, tagName) => {
+  try {
+    const { data, error } = await supabase.rpc("get_posts_by_tag_and_club", {
+      input_club_id: clubId,
+      input_tag_name: tagName,
+    });
+
+    if (error) {
+      throw error;
+    }
+
+    return data; // 반환된 데이터
+  } catch (error) {
+    console.error("Error fetching posts:", error.message);
+    throw error;
+  }
+};
+
+// 특정 맛집 게시물 조회 ✅
+const getRestaurantPostById = async (postId) => {
+  const { data, error } = await supabase
+    .from("restaurant_post")
+    .select("*")
+    .eq("id", postId)
+    .single();
+
+  if (error) {
+    console.error("Error fetching restaurant post:", error);
+    return null;
+  }
+  return data;
+};
+
+// 맛집 게시물 수정 ✅
+const updateRestaurantPost = async (
+  postId,
+  content,
+  title,
+  thumbnailUrl,
+  tags
+) => {
+  const { data: postData, error: postError } = await supabase
+    .from("restaurant_post")
+    .update({ content, title, thumbnail_url: thumbnailUrl, tags: tags })
+    .eq("id", postId)
+    .select();
+
+  if (postError) {
+    console.error("Error updating restaurant post:", postError);
+    return null;
+  }
+
+  return postData;
+};
+
+// 특정 게시물의 tags 수정 ✅
+// newTags 매개변수가 없으면 알아서 null로 처리되며 클럽으로만 필터링
+const updateRestaurantPostTags = async (postId, newTags) => {
+  const { data, error } = await supabase
+    .from("restaurant_post")
+    .update({ tags: newTags })
+    .eq("id", postId)
+    .select();
+
+  if (error) {
+    console.error("Error updating restaurant post tags:", error);
+    return null;
+  }
+  return data;
+};
+
+// 맛집 게시물 삭제 ✅
+const deleteRestaurantPost = async (postId) => {
+  const { error: tagRecordError } = await supabase
+    .from("viewing_restaurant_tag_record")
+    .delete()
+    .eq("viewing_restaurant_id", postId);
+
+  if (tagRecordError) {
+    console.error("Error deleting tag records:", tagRecordError);
+    return null;
+  }
+
+  const { data, error } = await supabase
+    .from("restaurant_post")
+    .delete()
+    .eq("id", postId);
+
+  if (error) {
+    console.error("Error deleting restaurant post:", error);
+    return null;
+  }
+
+  return data;
+};
+
+export default {
+  createRestaurantPost,
+  getRestaurantPostsByTagAndClub,
+  getRestaurantPostById,
+  updateRestaurantPost,
+  deleteRestaurantPost,
+  updateRestaurantPostTags,
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> #57 

## 📝작업 내용

![image](https://github.com/user-attachments/assets/b59edcbf-8340-42b3-b8fc-63f3290eaa2e)

- 중복으로 눌리는 것 방지하는 함수 ✅
// 특정 사용자가 특정 게시물에 좋아요를 눌렀는지 확인할 수 있는 함수 ✅ (중복 방지하는 함수에 data로 상태 반환)
// 렌더링 되는 대로 가상 테이블 가져오는 함수 (restaurant_post만 완료) ✅ 
![image](https://github.com/user-attachments/assets/ce1eea06-8252-4e93-aba2-fba6fcbd291f)

좋아요 중복 방지 이중 처리 데이터베이스 + 애플리케이션 방면 모두에서 좋아요 중복 방지를 처리 
