### PR TITLE
[FEAT] 자유게시판 Quill 태그 삭제 구현

### DIFF
--- a/src/components/CommentSection.vue
+++ b/src/components/CommentSection.vue
@@ -6,13 +6,16 @@ import commentBtnIcon from "@/assets/icons/comment_btn.svg";
 
 const props = defineProps({
   likeLength: {
-    type: Boolean,
-    required: false,
-    default: false, // 기본값은 false로 설정
+    type: Number,
+    default() {
+      return 0;
+    },
   },
   commentLength: {
-    type: String,
-    required: true,
+    type: Number,
+    default() {
+      return 0;
+    },
   },
 });
 </script>

--- a/src/components/freeboard/FreeBoardPost.vue
+++ b/src/components/freeboard/FreeBoardPost.vue
@@ -10,10 +10,11 @@ import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import "dayjs/locale/ko"; // 한국어 로케일 가져오기
 import { useRoute } from "vue-router";
+import { computed } from "vue";
 dayjs.extend(relativeTime); // relativeTime 플러그인 활성화
 dayjs.locale("ko"); // 한국어 로케일 설정
 
-const props = defineProps({
+defineProps({
   post: {
     type: Object,
   },
@@ -23,38 +24,42 @@ const props = defineProps({
   <div class="flex w-full pb-[20px] border-b border-white02">
     <!-- 라우터 처리 -->
     <RouterLink
-      :to="`/${route.params.team}/freeboard/${props.post.post_id}`"
+      :to="`/${route.params.team}/freeboard/${post.post_id}`"
       class="flex gap-[30px] w-full cursor-pointer"
     >
       <!-- 왼쪽 이미지 -->
-      <div>
-        <img
-          :src="props.post.thumbnail_url || defaultImg"
-          alt="게시물 이미지"
-          class="w-[150px] h-[150px] min-w-[150px] min-h-[150px] rounded-[10px] border border-white01"
-        />
-      </div>
+      <img
+        :src="post.thumbnail_url || defaultImg"
+        alt="게시물 이미지"
+        class="w-[150px] h-[150px] min-w-[150px] min-h-[150px] rounded-[10px] border border-white01"
+      />
+
       <!-- 오른쪽 게시물 정보 -->
-      <div class="flex py-[10px] flex-col justify-between">
+      <div class="flex py-[10px] flex-col justify-between w-[810px]">
         <!-- 제목 / 내용 -->
         <div class="flex flex-col gap-[10px] text-black01">
-          <span class="text-xl font-bold leading-[24px]">{{
-            props.post.title
-          }}</span>
-          <span class="text-gray03 leading-[19px]">{{
-            props.post.content
-          }}</span>
+          <span class="text-xl font-bold leading-[24px]">{{ post.title }}</span>
+          <span
+            class="text-gray03 leading-[19px]"
+            style="
+              display: -webkit-box;
+              -webkit-box-orient: vertical;
+              -webkit-line-clamp: 2;
+              overflow: hidden;
+            "
+            >{{
+              post.content.replace(/<br\s*\/?>/g, " ").replace(/<[^>]+>/g, "")
+            }}</span
+          >
         </div>
         <!-- 닉네임 / 작성일 -->
         <div class="flex text-xs gap-[10px] leading-[14px]">
-          <span class="font-bold text-gray03">{{
-            props.post.author_name
-          }}</span>
+          <span class="font-bold text-gray03">{{ post.author_name }}</span>
           <span class="text-gray02">
-            {{ dayjs(props.post.created_at).format("YYYY.MM.DD") }}</span
+            {{ dayjs(post.created_at).format("YYYY.MM.DD") }}</span
           >
           <span class="text-gray02">{{
-            dayjs(props.post.created_at).fromNow()
+            dayjs(post.created_at).fromNow()
           }}</span>
         </div>
         <!-- 좋아요 / 댓글 -->
@@ -63,7 +68,7 @@ const props = defineProps({
         >
           <div class="flex gap-[10px]">
             <img :src="likeIcon" alt="하트 이미지" class="w-[16px] h-[14px]" />
-            <span>{{ props.post.like_count }}</span>
+            <span>{{ post.like_count }}</span>
           </div>
           <div class="flex gap-[10px]">
             <img
@@ -72,7 +77,7 @@ const props = defineProps({
               class="w-[16px] h-[14px]"
               ß
             />
-            <span>{{ props.post.comment_count }}</span>
+            <span>{{ post.comment_count }}</span>
           </div>
         </div>
       </div>

--- a/src/pages/FreeBoard.vue
+++ b/src/pages/FreeBoard.vue
@@ -2,20 +2,21 @@
 import FreeBoardPost from "@/components/freeboard/FreeBoardPost.vue";
 import PostArrow from "@/assets/icons/post_arrow.svg";
 import { useRoute } from "vue-router";
-import { onMounted, ref } from "vue";
+import { onMounted, ref, watch } from "vue";
 import { getFreePostsByClub } from "@/api/supabase-api/freePost";
+import { teamID } from "@/constants";
 
 const route = useRoute();
-const teamName = ref(route.params.team);
+const teamName = ref(route.params.team); // url 팀 이름 불러오기
+const clubId = ref(teamID[teamName.value]); // 팀 id 가져오기
 
 const freeboardList = ref([]);
 
 // 자유 게시판 목록 가져오는 함수
 const fetchFreeboard = async () => {
   try {
-    const data = await getFreePostsByClub(1);
-    console.log(data);
-    freeboardList.value = data;
+    const data = await getFreePostsByClub(clubId.value);
+    freeboardList.value = data || [];
   } catch (error) {
     console.error("데이터를 불러오는 동안 에러가 발생하였습니다.");
   }
@@ -24,6 +25,17 @@ const fetchFreeboard = async () => {
 onMounted(() => {
   fetchFreeboard();
 });
+
+// route.params.team이 변경될 때마다 반응
+watch(
+  () => route.params.team,
+  (newTeamName, _) => {
+    // 업데이트
+    teamName.value = newTeamName;
+    clubId.value = teamID[teamName.value];
+    fetchFreeboard();
+  }
+);
 </script>
 <template>
   <div class="flex flex-col px-[50px] py-[30px] items-center">
@@ -40,12 +52,17 @@ onMounted(() => {
       </div>
 
       <!-- 목록 -->
-      <div class="flex flex-col w-full h-full gap-[20px]">
-        <FreeBoardPost
-          v-for="(post, index) in freeboardList"
-          :key="index"
-          :post="post"
-        />
+      <div class="flex flex-col w-full h-full gap-[20px] items-center">
+        <template v-if="freeboardList.length > 0">
+          <FreeBoardPost
+            v-for="(post, index) in freeboardList"
+            :key="index"
+            :post="post"
+          />
+        </template>
+        <template v-else>
+          <h1>데이터가 없습니다.</h1>
+        </template>
       </div>
     </div>
   </div>

--- a/src/pages/FreeBoardCreate.vue
+++ b/src/pages/FreeBoardCreate.vue
@@ -70,7 +70,6 @@ const handleCancel = () => {
           theme="snow"
           toolbar="full"
         />
-        <div v-html="content" class="border-2 border-blue-500 ql-editor"></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> quill을 이용해서 태그 형식으로 내용을 저장하고,  불러올 때 정규식을 통해서 태그 부분은 삭제하였습니다.
추가적으로 <br>인 경우는 공백처리를 통해서 구분하기 쉽게 하였습니다.

## 📸 스크린샷
<img width="1712" alt="image" src="https://github.com/user-attachments/assets/97f0cdbb-d07b-4bec-b904-655d819b9740" />


## 💬리뷰 요구사항(선택)
