### PR TITLE
[FEAT] 댓글 작성 / 댓글 목록 불러오기

### DIFF
--- a/src/api/supabase-api/common.js
+++ b/src/api/supabase-api/common.js
@@ -1,0 +1,28 @@
+import { supabase } from "@/supabase";
+
+// 게시물 댓글 조회
+export const getComments = async (table, postId) => {
+  const { data, error } = await supabase
+    .from(table)
+    .select("*")
+    .eq("post_id", postId);
+
+  if (error) {
+    console.error("Error fetching free post comments:", error);
+    return null;
+  }
+  return data;
+};
+
+// 게시물에 댓글 추가
+export const createComment = async (table, memberId, postId, content) => {
+  const { data, error } = await supabase
+    .from(table)
+    .insert([{ member_id: memberId, post_id: postId, content }]);
+
+  if (error) {
+    console.error("Error creating free post comment:", error);
+    return null;
+  }
+  return data;
+};

--- a/src/components/CommentSection.vue
+++ b/src/components/CommentSection.vue
@@ -3,11 +3,22 @@ import Commentbox from "./Commentbox.vue";
 import likeIcon from "@/assets/icons/like.svg";
 import commentIcon from "@/assets/icons/comment.svg";
 import commentBtnIcon from "@/assets/icons/comment_btn.svg";
-import { ref } from "vue";
+import { onMounted, ref } from "vue";
+import { useRoute } from "vue-router";
+import {
+  createFreePostComment,
+  getFreePostComments,
+} from "@/api/supabase-api/freePost";
+import {
+  createPostComment,
+  getCrewRecruitmentPostComments,
+} from "@/api/supabase-api/crewRecruitmentPost";
+import { getCertificationPostComments } from "@/api/supabase-api/viewingCertificationPostComment";
+import { createRestaurantPostComment } from "@/api/supabase-api/restaurantComment";
+import { createComment, getComments } from "@/api/supabase-api/common";
+import { boardToCommentTableMapping } from "@/constants";
 
-const text = ref("");
-
-const props = defineProps({
+defineProps({
   likeLength: {
     type: Number,
     default() {
@@ -21,12 +32,62 @@ const props = defineProps({
     },
   },
 });
-// 사용자 정의 이벤트 정의
-const emits = defineEmits(["createComment"]);
-// 이벤트 트리거 함수
-const createComment = (text) => {
-  emits("createComment", text);
+
+const route = useRoute();
+const post_id = ref(route.params.id);
+const boardName = route.path.split("/")[2]; // 게시판 이름
+
+const text = ref("");
+const comments = ref([]);
+
+// 어떤 댓글 생성하는 함수를 사용할지에 대한 함수
+const getCommentCreationFunction = () => {
+  const boardName = route.path.split("/")[2];
+  if (boardName === "freeboard") {
+    return createFreePostComment;
+  } else if (boardName === "crewboard") {
+    return createPostComment;
+  } else if (boardName === "photoboard") {
+    return getCertificationPostComments;
+  }
+  // foodboard
+  else {
+    return createRestaurantPostComment;
+  }
 };
+
+// // 댓글 생성하는 함수
+const FectCreateComment = async (comment) => {
+  try {
+    const data = await createComment(
+      boardToCommentTableMapping[boardName],
+      "d9ac20dc-af86-42e8-9d63-5f1e35b20547", // member ID,
+      post_id.value,
+      comment
+    );
+    console.log(data);
+  } catch (error) {
+    console.error("댓글 작성중 오류가 생겼습니다.");
+  }
+};
+
+// 댓글 정보 가져오는 함수
+const fetchGetComments = async () => {
+  try {
+    const data = await getComments(
+      boardToCommentTableMapping[boardName],
+      post_id.value
+    );
+    console.log(data);
+    comments.value = data;
+  } catch (error) {
+    console.error("댓글 정보를 가져오는 중에 오류가 발생했습니다.");
+  }
+};
+
+onMounted(() => {
+  fetchGetComments();
+});
 </script>
 <template>
   <div class="px-[30px] flex flex-col gap-[30px]">
@@ -34,11 +95,11 @@ const createComment = (text) => {
     <div class="flex gap-[20px]">
       <div class="flex gap-[10px]">
         <img :src="likeIcon" alt="좋아요 아이콘" class="w-[21px] h-18px" />
-        <span class="text-gray02">{{ props.likeLength }}</span>
+        <span class="text-gray02">{{ likeLength }}</span>
       </div>
       <div class="flex gap-[10px]">
         <img :src="commentIcon" alt="댓글 아이콘" class="w-[21px] h-18px" />
-        <span class="text-gray02">{{ props.commentLength }}</span>
+        <span class="text-gray02">{{ commentLength }}</span>
       </div>
     </div>
 
@@ -53,7 +114,7 @@ const createComment = (text) => {
         v-model="text"
       />
 
-      <button @click="createComment(text)">
+      <button @click="FectCreateComment(text)">
         <img
           :src="commentBtnIcon"
           alt="댓글 전송 버튼"
@@ -63,10 +124,7 @@ const createComment = (text) => {
     </div>
     <!-- 댓글리스트 -->
     <div class="flex flex-col gap-5">
-      <Commentbox />
-      <Commentbox />
-      <Commentbox />
-      <Commentbox />
+      <Commentbox v-for="comment of comments" :comment />
     </div>
   </div>
 </template>

--- a/src/components/Commentbox.vue
+++ b/src/components/Commentbox.vue
@@ -1,4 +1,18 @@
-<script setup></script>
+<script setup>
+defineProps({
+  comment: {
+    type: Object,
+  },
+});
+
+// day.js
+import dayjs from "dayjs";
+import relativeTime from "dayjs/plugin/relativeTime";
+import "dayjs/locale/ko"; // 한국어 로케일 가져오기
+import { useRoute } from "vue-router";
+dayjs.extend(relativeTime); // relativeTime 플러그인 활성화
+dayjs.locale("ko"); // 한국어 로케일 설정
+</script>
 <template>
   <div class="pb-5 border-b border-white02">
     <div class="flex items-center justify-between">
@@ -9,7 +23,9 @@
           class="w-[35px] h-[35px] rounded-full"
         />
         <span class="text-sm font-bold text-gray03">닉네임</span>
-        <span class="text-xs text-gray02">1분 전</span>
+        <span class="text-xs text-gray02">{{
+          dayjs(comment.created_at).fromNow()
+        }}</span>
       </div>
       <div class="flex text-xs text-gray02 gap-[4px] border border-blue-500">
         <button class="hover:text-gray03">수정</button>
@@ -18,7 +34,7 @@
       </div>
     </div>
     <div class="pl-[45px]">
-      <span class="text-[#515151]">댓글 테스트 중입니다.</span>
+      <span class="text-[#515151]">{{ comment.content }}</span>
     </div>
   </div>
 </template>

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -105,3 +105,10 @@ export const foodBoardTag = [
   "# 야구장 주변 맛집",
   "# 야구 볼 수 있는 식당",
 ];
+
+export const boardToCommentTableMapping = {
+  freeboard: "free_post_comment",
+  crewboard: "crew_recruitment_post_comment",
+  photoboard: "viewing_certification_post_comment",
+  foodboard: "restaurant_post_comment",
+};

--- a/src/pages/FreeBoardDetail.vue
+++ b/src/pages/FreeBoardDetail.vue
@@ -1,8 +1,5 @@
 <script setup>
-import {
-  createFreePostComment,
-  getFreePostDetailsById,
-} from "@/api/supabase-api/freePost";
+import { getFreePostDetailsById } from "@/api/supabase-api/freePost";
 import backIcon from "@/assets/icons/back.svg";
 import CommentSection from "@/components/CommentSection.vue";
 import PostHeader from "@/components/PostHeader.vue";
@@ -29,19 +26,6 @@ const fetchFreeboardDetail = async (id) => {
     post.value = data;
   } catch (error) {
     console.error("데이터를 불러오는 도중에 오류가 발생했습니다.");
-  }
-};
-
-// 댓글 생성하는 사용자 정의 함수
-const createComment = async (comment) => {
-  try {
-    const data = createFreePostComment(
-      "d9ac20dc-af86-42e8-9d63-5f1e35b20547", // member ID,
-      post_id.value,
-      comment
-    );
-  } catch (error) {
-    console.error("댓글 작성중 오류가 생겼습니다.");
   }
 };
 
@@ -75,7 +59,6 @@ onMounted(() => {
       <CommentSection
         :likeLength="post.like_count"
         :commentLength="post.comment_count"
-        @create-comment="createComment"
       />
     </div>
   </div>


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

## 📝작업 내용

> 댓글 작성 / 댓글 목록 불러오기 구현하였습니다.
각 게시판 마다 댓글 목록 불러오는 함수가 달라서 간단하게 common.js에 공통 함수 만들었습니다.
또한 현재 댓글 물러올 때 / 닉네임 / 유저 프로필 부분이 아직 들어오지 않고,
댓글을 업데이트해야하는데 리턴 값이 없어서 어떻게 구현해야할지 고민중입니다.

## 📸 스크린샷
<img width="1711" alt="image" src="https://github.com/user-attachments/assets/ea74ea6e-4924-48d3-b8f6-ba49723b4c98" />


## 💬리뷰 요구사항(선택)
