### PR TITLE
[FEAT] 헤더 유저 정보 추가

### DIFF
--- a/src/components/ui/Header.vue
+++ b/src/components/ui/Header.vue
@@ -91,12 +91,12 @@ const toggleDropdown = () => {
           class="flex items-center gap-[15px] cursor-pointer"
         >
           <img
-            :src="authStore.user.image || defaultImg"
+            :src="authStore.user?.image || defaultImg"
             alt="유저 프로필"
             class="w-10 h-10 rounded-full"
           />
           <span class="font-bold text-gray03">{{
-            authStore.user.name || "비회원"
+            authStore.user?.name || "비회원"
           }}</span>
         </RouterLink>
         <!-- 테마 -->


### PR DESCRIPTION
## #️⃣연관된 이슈

> #202 

## 📝작업 내용

> 헤더에 유저 정보 추가하였습니다. 로그인 정보가 없을 경우 디폴트 이미지와 비회원으로 쓰게 설정했습니다.

## 📸 스크린샷
로그인시
<img width="1711" alt="image" src="https://github.com/user-attachments/assets/a9450bb8-35b5-474e-ba6b-b3483eb29da3" />


## 💬리뷰 요구사항(선택)
